### PR TITLE
Use proper PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["laravel", "illuminate", "roman", "roman-number", "roman-numeral", "converter", "format", "validator"],
     "require": {
-        "php": "^7.0",
+        "php": ">=7.0",
         "wandersonwhcr/romans": "^1.0",
         "illuminate/support": "^5.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "eccadf6b0ef3957e779bbce763d7673b",
+    "content-hash": "cceaacc469cc79d4f8937d319776e382",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -2001,7 +2001,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
When using PHP `^7.0` as package requirement, the package will be failed to install on PHP 7.1 or higher, since Composer would always throw `Package x at version y has a PHP requirement incompatible with your PHP version`